### PR TITLE
Fix vdp_prefix_seen logic

### DIFF
--- a/src/hdmi_input.vhd
+++ b/src/hdmi_input.vhd
@@ -552,10 +552,10 @@ hdmi_section_decode: process(clk_pixel)
             ------------------------------------------------------------
             vdp_prefix_detect <= vdp_prefix_detect(6 downto 0) & '0';
             vdp_prefix_seen <= '0';
-            if ch0_ctl_valid = '1' and ch1_ctl_valid = '1' and ch1_ctl_valid = '1' then
+            if ch0_ctl_valid = '1' and ch1_ctl_valid = '1' and ch2_ctl_valid = '1' then
                 if ch1_ctl = "01" and ch2_ctl = "00" then
                     vdp_prefix_detect(0) <=  '1';
-                    if vdp_prefix_detect = "01111111" then
+                    if vdp_prefix_detect(6 downto 0) = "1111111" then
                         vdp_prefix_seen <= '1';
                     end if;
                 end if;
@@ -569,10 +569,10 @@ hdmi_section_decode: process(clk_pixel)
             ---------------------------------------------
             adp_prefix_detect <= adp_prefix_detect(6 downto 0) & '0';
             adp_prefix_seen <= '0';
-            if ch0_ctl_valid = '1' and ch1_ctl_valid = '1' and ch1_ctl_valid = '1' then
+            if ch0_ctl_valid = '1' and ch1_ctl_valid = '1' and ch2_ctl_valid = '1' then
                 if ch1_ctl = "01" and ch2_ctl = "01" then
                     adp_prefix_detect(0) <= '1';
-                    if adp_prefix_detect = "01111111" then
+                    if adp_prefix_detect(6 downto 0) = "1111111" then
                         adp_prefix_seen <= '1';
                     end if;
                 end if;
@@ -584,7 +584,7 @@ hdmi_section_decode: process(clk_pixel)
             -- encoded in TERC4 coded in Ch0 - annoying!
             ---------------------------------------------
             adp_guardband_detect <= '0';
-            if in_vdp = '0' and ch0_terc4_valid = '1' and ch1_guardband_valid = '1' and ch1_guardband_valid = '1' then
+            if in_vdp = '0' and ch0_terc4_valid = '1' and ch1_guardband_valid = '1' and ch2_guardband_valid = '1' then
                 if ch0_terc4(3 downto 2) = "11" and ch1_guardband = "0" and ch2_guardband = "0" then
                     raw_vsync <= ch0_terc4(1);
                     raw_hsync <= ch0_terc4(0);

--- a/src/tmds_decoder.vhd
+++ b/src/tmds_decoder.vhd
@@ -131,7 +131,6 @@ decode_ctl:  process(clk)
                     when x"4B"  => terc4_valid <= '1'; terc4 <= "1001"; -- "0100111001" TERC4 1001
                     when x"A4"  => terc4_valid <= '1'; terc4 <= "1010"; -- "0110011100" TERC4 1010
                     when x"B5"  => terc4_valid <= '1'; terc4 <= "1011"; -- "1011000110" TERC4 1011
-                    when x"B5"  => terc4_valid <= '1'; terc4 <= "1011"; -- "1011000110" TERC4 1011
                     when x"6D"  => terc4_valid <= '1'; terc4 <= "1100"; -- "1010001110" TERC4 1100
                     when x"6C"  => terc4_valid <= '1'; terc4 <= "1101"; -- "1001110001" TERC4 1101
                     when x"A5"  => terc4_valid <= '1'; terc4 <= "1110"; -- "0101100011" TERC4 1110


### PR DESCRIPTION
Keep vdp_prefix_seen asserted even if we see more than eight preamble
characters in a row.  Apply the same logic to adp_prefix_seen although
it should not be necessary (the HDMI Standard specifies the data island
preamble shall not be transmitted except for it's correct use during a
preamble period).

Fix some instances where ch1_* signals were referenced twice in some
conditional statements instead of using ch1_* and ch2_*

Signed-off-by: Charles Steinkuehler <cstein@newtek.com>